### PR TITLE
Only download EFI and OcBinaryData if using libguestfs

### DIFF
--- a/generate-unique-machine-values.sh
+++ b/generate-unique-machine-values.sh
@@ -384,7 +384,9 @@ EOF
     [ -d "${OUTPUT_DIRECTORY}" ] || mkdir -p "${OUTPUT_DIRECTORY}"
     [ -e ./macserial ] || build_mac_serial
     download_vendor_mac_addresses
-    download_qcow_efi_folder
+    if [ "${CREATE_BOOTDISKS}" ] || [ "${OUTPUT_BOOTDISK}" ]; then
+        download_qcow_efi_folder
+    fi
     generate_serial_sets
     echo "${SERIAL_SETS_FILE}"    
 }


### PR DESCRIPTION
Issue outlined in https://github.com/dortania/OpenCore-Post-Install/pull/59#issuecomment-804079719