### PR TITLE
Thinkpads

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,51 @@ CUSTOM_PLIST=https://raw.githubusercontent.com/sickcodes/osx-serial-generator/ma
     --height 1080
 ```
 
+## Thinkpad Errors in OpenCore
+
+If you have errors related to a think pad, try toggling `--thinkpad`.
+
+This will set `ForceOcWriteFlash` to `true`, as per https://dortania.github.io/docs/latest/Configuration.html
+
+## Rough example used in Docker-OSX in a Dockerfile
+
+```dockerfile
+
+ARG STOCK_DEVICE_MODEL=iMacPro1,1
+ARG STOCK_SERIAL=C02TM2ZBHX87
+ARG STOCK_BOARD_SERIAL=C02717306J9JG361M
+ARG STOCK_UUID=007076A6-F2A2-4461-BBE5-BAD019F8025A
+ARG STOCK_MAC_ADDRESS=00:0A:27:00:00:00
+ARG STOCK_WIDTH=1920
+ARG STOCK_HEIGHT=1080
+ARG STOCK_MASTER_PLIST_URL=https://raw.githubusercontent.com/sickcodes/osx-serial-generator/master/config-custom.plist
+ARG STOCK_MASTER_PLIST_URL_NOPICKER=https://raw.githubusercontent.com/sickcodes/osx-serial-generator/master/config-nopicker-custom.plist
+ARG STOCK_BOOTDISK=/home/arch/OSX-KVM/OpenCore/OpenCore.qcow2
+ARG STOCK_BOOTDISK_NOPICKER=/home/arch/OSX-KVM/OpenCore/OpenCore-nopicker.qcow2
+
+RUN ./generate-specific-bootdisk.sh \
+    --master-plist-url="${STOCK_MASTER_PLIST_URL}" \
+    --model "${STOCK_DEVICE_MODEL}" \
+    --serial "${STOCK_SERIAL}" \
+    --board-serial "${STOCK_BOARD_SERIAL}" \
+    --uuid "${STOCK_UUID}" \
+    --mac-address "${STOCK_MAC_ADDRESS}" \
+    --width "${STOCK_WIDTH}" \
+    --height "${STOCK_HEIGHT}" \
+    --output-bootdisk "${STOCK_BOOTDISK}" || exit 1
+
+RUN ./generate-specific-bootdisk.sh \
+    --master-plist-url="${STOCK_MASTER_PLIST_URL_NOPICKER}" \
+    --model "${STOCK_DEVICE_MODEL}" \
+    --serial "${STOCK_SERIAL}" \
+    --board-serial "${STOCK_BOARD_SERIAL}" \
+    --uuid "${STOCK_UUID}" \
+    --mac-address "${STOCK_MAC_ADDRESS}" \
+    --width "${STOCK_WIDTH}" \
+    --height "${STOCK_HEIGHT}" \
+    --output-bootdisk "${STOCK_BOOTDISK_NOPICKER}" || exit 1
+```
+
 
 # Examples from Docker-OSX
 

--- a/config-custom.plist
+++ b/config-custom.plist
@@ -1378,7 +1378,7 @@
 			<key>ExitBootServicesDelay</key>
 			<integer>0</integer>
 			<key>ForceOcWriteFlash</key>
-			<false/>
+			<{{THINKPAD}}/>
 			<key>ForgeUefiSupport</key>
 			<false/>
 			<key>IgnoreInvalidFlexRatio</key>

--- a/config-nopicker-custom.plist
+++ b/config-nopicker-custom.plist
@@ -1378,7 +1378,7 @@
 			<key>ExitBootServicesDelay</key>
 			<integer>0</integer>
 			<key>ForceOcWriteFlash</key>
-			<false/>
+			<{{THINKPAD}}/>
 			<key>ForgeUefiSupport</key>
 			<false/>
 			<key>IgnoreInvalidFlexRatio</key>

--- a/generate-specific-bootdisk.sh
+++ b/generate-specific-bootdisk.sh
@@ -30,10 +30,11 @@ Optional options:
     --master-plist <filename>       Same as above.
     --output-bootdisk <filename>    Optionally change the bootdisk filename
     --output-plist <filename>       Optionally change the output plist filename
+    --thinkpad                      Sets ForceOcWriteFlash to true
     --help, -h, help                Display this help and exit
 
 Placeholders:   {{DEVICE_MODEL}}, {{SERIAL}}, {{BOARD_SERIAL}}, {{UUID}},
-                {{ROM}}, {{WIDTH}}, {{HEIGHT}}
+                {{ROM}}, {{WIDTH}}, {{HEIGHT}}, {{THINKPAD}}
 
 Example:
     ./generate-specific-bootdisk.sh \\
@@ -183,6 +184,12 @@ while (( "$#" )); do
                 shift
             ;;
 
+    
+    --thinkpad )
+                export THINKPAD=true
+                shift
+            ;;
+
     *)
                 echo "Invalid option ${1}. Running with default values..."
                 shift
@@ -233,6 +240,13 @@ generate_bootdisk () {
         wget -O "${MASTER_PLIST:=./config-nopicker-custom.plist}" "${MASTER_PLIST_URL}"
     fi
 
+    if [[ "${THINKPAD}" == true ]]; then
+        echo "Thinkpads: setting ForceOcWriteFlash to true"
+        export THINKPAD=true
+    else
+        export THINKPAD=false
+    fi
+
     [ -e ./opencore-image-ng.sh ] \
         || { wget "${OPENCORE_IMAGE_MAKER_URL}" \
             && chmod +x opencore-image-ng.sh ; }
@@ -252,6 +266,7 @@ generate_bootdisk () {
             -e s/\{\{ROM\}\}/"${ROM}"/g \
             -e s/\{\{WIDTH\}\}/"${WIDTH:-1920}"/g \
             -e s/\{\{HEIGHT\}\}/"${HEIGHT:-1080}"/g \
+            -e s/\{\{THINKPAD\}\}/"${THINKPAD:-false}"/g \
             "${MASTER_PLIST}" > ./tmp.config.plist || exit 1
     else
         cat <<EOF && exit 1

--- a/generate-unique-machine-values.sh
+++ b/generate-unique-machine-values.sh
@@ -30,6 +30,7 @@ General options:
     --create-envs, --envs           Create all corresponding sourcable envs
     --create-plists, --plists       Create all corresponding config.plists
     --create-bootdisks, --bootdisks Create all corresponding bootdisks [SLOW]
+    --thinkpad                      Toggles ForceOcWriteFlash to true
     --help, -h, help                Display this help and exit
 
 Additional options only if you are creating ONE serial set:
@@ -38,7 +39,7 @@ Additional options only if you are creating ONE serial set:
 
 Custom plist placeholders:
     {{DEVICE_MODEL}}, {{SERIAL}}, {{BOARD_SERIAL}},
-    {{UUID}}, {{ROM}}, {{WIDTH}}, {{HEIGHT}}
+    {{UUID}}, {{ROM}}, {{WIDTH}}, {{HEIGHT}}, {{THINKPAD}}
 
 Example:
     ./generate-unique-machine-values.sh --count 1 --plists --bootdisks --envs
@@ -202,9 +203,14 @@ while (( "$#" )); do
                 export CREATE_ENVS=1
                 shift
             ;;
+    
+    --thinkpad )
+                export THINKPAD=true
+                shift
+            ;;
 
     *)
-                echo "Invalid option. Running with default values..."
+                echo "Invalid option ${1}. Running with default values..."
                 shift
             ;;
     esac
@@ -313,6 +319,7 @@ export UUID="${UUID}"
 export MAC_ADDRESS="${MAC_ADDRESS}"
 export WIDTH="${WIDTH}"
 export HEIGHT="${HEIGHT}"
+export THINKPAD="${THINKPAD}"
 EOF
 
             fi
@@ -333,6 +340,13 @@ EOF
                     wget -O "${MASTER_PLIST:=./config-nopicker-custom.plist}" "${MASTER_PLIST_URL}"
                 fi
 
+                if [[ "${THINKPAD}" == true ]]; then
+                    echo "Thinkpads: setting ForceOcWriteFlash to true"
+                    export THINKPAD=true
+                else
+                    export THINKPAD=false
+                fi
+
                 mkdir -p "${OUTPUT_DIRECTORY}/plists"
                 source "${OUTPUT_ENV_FILE}"
                 ROM="${MAC_ADDRESS//\:/}"
@@ -344,6 +358,7 @@ EOF
                     -e s/\{\{ROM\}\}/"${ROM}"/g \
                     -e s/\{\{WIDTH\}\}/"${WIDTH}"/g \
                     -e s/\{\{HEIGHT\}\}/"${HEIGHT}"/g \
+                    -e s/\{\{THINKPAD\}\}/"${THINKPAD}"/g \
                     "${MASTER_PLIST}" > "${OUTPUT_DIRECTORY}/plists/${SERIAL}.config.plist" || exit 1
             fi
 


### PR DESCRIPTION
Note with Thinkpads the following from https://dortania.github.io/docs/latest/Configuration.html

>ForceOcWriteFlash
>Type: plist boolean
>Failsafe: false
>Description: Enables writing to flash memory for all OpenCore system variables.

>Note: This value should be disabled on most types of firmware but is left configurable to account for firmware that may have issues with volatile variable storage overflows or similar. Boot issues across multiple OSes can be observed on e.g. Lenovo Thinkpad T430 and T530 without this quirk. Apple variables related to Secure Boot and hibernation are exempt from this for security reasons. Furthermore, some OpenCore variables are exempt for different reasons, such as the boot log due to an available user option, and the TSC frequency due to timing issues. When toggling this option, a NVRAM reset may be required to ensure full functionality. 
```