### PR TITLE
Update MAC vendor list

### DIFF
--- a/generate-unique-machine-values.sh
+++ b/generate-unique-machine-values.sh
@@ -222,7 +222,7 @@ build_mac_serial () {
 
 download_vendor_mac_addresses () {
     # download the MAC Address vendor list
-    [ -e "${MAC_ADDRESSES_FILE:=vendor_macs.tsv}" ] || curl -L -o "${MAC_ADDRESSES_FILE}" https://gitlab.com/wireshark/wireshark/-/raw/master/manuf
+    [ -e "${MAC_ADDRESSES_FILE:=vendor_macs.tsv}" ] || curl -L -o "${MAC_ADDRESSES_FILE}" https://gitlab.com/wireshark/wireshark/-/raw/release-3.6/manuf
 }
 
 download_qcow_efi_folder () {


### PR DESCRIPTION
Since Wireshark 4.0 the vendor list is no longer in plain text. Update the URL to point to the last release of 3.6.